### PR TITLE
feat: Add PVC and VS labeling with user data preservation

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,10 +35,23 @@ func main() {
 		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-vmi-action", newVMIRestoreItemAction).
 		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-pvc-action", newPVCRestoreItemAction).
 		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-pod-action", newPodRestoreItemAction).
+		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-volumesnapshot-action", newVolumeSnapshotRestoreItemAction).
 		RegisterBackupItemAction("kubevirt-velero-plugin/backup-datavolume-action", newDVBackupItemAction).
+		RegisterBackupItemAction("kubevirt-velero-plugin/backup-pvc-action", newPVCBackupItemAction).
+		RegisterBackupItemAction("kubevirt-velero-plugin/backup-volumesnapshot-action", newVolumeSnapshotBackupItemAction).
 		RegisterBackupItemAction("kubevirt-velero-plugin/backup-virtualmachine-action", newVMBackupItemAction).
 		RegisterBackupItemAction("kubevirt-velero-plugin/backup-virtualmachineinstance-action", newVMIBackupItemAction).
 		Serve()
+}
+
+func newPVCBackupItemAction(logger logrus.FieldLogger) (interface{}, error) {
+	logger.Debug("Creating PVCBackupItemAction")
+	return plugin.NewPVCBackupItemAction(logger), nil
+}
+
+func newVolumeSnapshotBackupItemAction(logger logrus.FieldLogger) (interface{}, error) {
+	logger.Debug("Creating VolumeSnapshotBackupItemAction")
+	return plugin.NewVolumeSnapshotBackupItemAction(logger), nil
 }
 
 func newDVBackupItemAction(logger logrus.FieldLogger) (interface{}, error) {
@@ -79,4 +92,9 @@ func newPVCRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {
 func newPodRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {
 	logger.Debug("Creating PodRestoreItemAction")
 	return plugin.NewPodRestoreItemAction(logger), nil
+}
+
+func newVolumeSnapshotRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {
+	logger.Debug("Creating VolumeSnapshotRestoreItemAction")
+	return plugin.NewVolumeSnapshotRestoreItemAction(logger), nil
 }

--- a/pkg/plugin/pvc_backup_item_action.go
+++ b/pkg/plugin/pvc_backup_item_action.go
@@ -1,0 +1,92 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2025 Red Hat, Inc.
+ *
+ */
+
+package plugin
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
+
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+)
+
+// PVCBackupItemAction is a backup item action for backing up PersistentVolumeClaims
+type PVCBackupItemAction struct {
+	log logrus.FieldLogger
+}
+
+// NewPVCBackupItemAction instantiates a PVCBackupItemAction.
+func NewPVCBackupItemAction(log logrus.FieldLogger) *PVCBackupItemAction {
+	return &PVCBackupItemAction{log: log}
+}
+
+// AppliesTo returns information about which resources this action should be invoked for.
+func (p *PVCBackupItemAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+			IncludedResources: []string{
+				"PersistentVolumeClaim",
+			},
+		},
+		nil
+}
+
+// Execute allows the ItemAction to perform arbitrary logic with the item being backed up,
+// in this case, adding UID labels to PVCs for selective restore functionality.
+func (p *PVCBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
+	p.log.Info("Executing PVCBackupItemAction")
+
+	metadata, err := meta.Accessor(item)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Add UID label for selective restore
+	labels := metadata.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	pvcUID := string(metadata.GetUID())
+	if pvcUID == "" {
+		extra := []velero.ResourceIdentifier{}
+		return item, extra, nil
+	}
+
+	// Handle collision detection - preserve original value if it exists
+	// Even if the existing value matches the UID, we need to preserve it
+	// because the user might have legitimately set this label themselves
+	if existingValue, exists := labels[util.PVCUIDLabel]; exists {
+		annotations := metadata.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[util.OriginalPVCUIDAnnotation] = existingValue
+		metadata.SetAnnotations(annotations)
+	}
+
+	labels[util.PVCUIDLabel] = pvcUID
+	metadata.SetLabels(labels)
+
+	extra := []velero.ResourceIdentifier{}
+	return item, extra, nil
+}

--- a/pkg/plugin/pvc_backup_item_action_test.go
+++ b/pkg/plugin/pvc_backup_item_action_test.go
@@ -1,0 +1,215 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
+)
+
+func TestPVCBackupExecute(t *testing.T) {
+	testCases := []struct {
+		name                string
+		pvc                 *corev1.PersistentVolumeClaim
+		expectedLabels      map[string]string
+		expectedAnnotations map[string]string
+		expectSkip          bool
+	}{
+		{
+			"Add UID label to PVC without existing labels",
+			&corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pvc",
+					Namespace: "test-namespace",
+					UID:       "pvc-uid-123",
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{},
+			},
+			map[string]string{
+				util.PVCUIDLabel: "pvc-uid-123",
+			},
+			map[string]string{},
+			false,
+		},
+		{
+			"Add UID label to PVC with existing labels",
+			&corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-labels-pvc",
+					Namespace: "test-namespace",
+					UID:       "pvc-uid-456",
+					Labels: map[string]string{
+						"existing-label": "existing-value",
+						"another-label":  "another-value",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{},
+			},
+			map[string]string{
+				util.PVCUIDLabel:  "pvc-uid-456",
+				"existing-label": "existing-value",
+				"another-label":  "another-value",
+			},
+			map[string]string{},
+			false,
+		},
+		{
+			"Preserve existing PVC UID label in annotation when collision occurs",
+			&corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "collision-pvc",
+					Namespace: "test-namespace",
+					UID:       "pvc-uid-789",
+					Labels: map[string]string{
+						util.PVCUIDLabel: "original-user-value",
+						"other-label":    "other-value",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{},
+			},
+			map[string]string{
+				util.PVCUIDLabel: "pvc-uid-789",
+				"other-label":    "other-value",
+			},
+			map[string]string{
+				util.OriginalPVCUIDAnnotation: "original-user-value",
+			},
+			false,
+		},
+		{
+			"Handle PVC with existing annotations and collision",
+			&corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-annotations-pvc",
+					Namespace: "test-namespace",
+					UID:       "pvc-uid-101",
+					Labels: map[string]string{
+						util.PVCUIDLabel: "user-set-value",
+					},
+					Annotations: map[string]string{
+						"existing-annotation": "existing-value",
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{},
+			},
+			map[string]string{
+				util.PVCUIDLabel: "pvc-uid-101",
+			},
+			map[string]string{
+				"existing-annotation":         "existing-value",
+				util.OriginalPVCUIDAnnotation: "user-set-value",
+			},
+			false,
+		},
+		{
+			"Skip PVC with empty UID",
+			&corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-uid-pvc",
+					Namespace: "test-namespace",
+					// UID is empty
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{},
+			},
+			map[string]string{},
+			map[string]string{},
+			true,
+		},
+		{
+			"Handle PVC with same UID value as existing label (preserve it anyway)",
+			&corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "same-uid-pvc",
+					Namespace: "test-namespace",
+					UID:       "pvc-uid-same",
+					Labels: map[string]string{
+						util.PVCUIDLabel: "pvc-uid-same", // Same as UID but user might have set it
+					},
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{},
+			},
+			map[string]string{
+				util.PVCUIDLabel: "pvc-uid-same",
+			},
+			map[string]string{
+				util.OriginalPVCUIDAnnotation: "pvc-uid-same", // Still preserve original
+			},
+			false,
+		},
+	}
+
+	logger := logrus.StandardLogger()
+	action := NewPVCBackupItemAction(logger)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Convert to unstructured
+			item, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tc.pvc)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			backup := &v1.Backup{}
+			result, _, err := action.Execute(&unstructured.Unstructured{Object: item}, backup)
+
+			if tc.expectSkip {
+				// For cases where we skip processing, just verify no error and item unchanged
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				assert.Equal(t, item, result.UnstructuredContent())
+				return
+			}
+
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			// Extract the result PVC
+			var resultPVC corev1.PersistentVolumeClaim
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(result.UnstructuredContent(), &resultPVC)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			// Verify expected labels are present
+			if resultPVC.Labels == nil {
+				resultPVC.Labels = make(map[string]string)
+			}
+
+			assert.Equal(t, len(tc.expectedLabels), len(resultPVC.Labels), "Unexpected number of labels")
+
+			for expectedKey, expectedValue := range tc.expectedLabels {
+				actualValue, exists := resultPVC.Labels[expectedKey]
+				assert.True(t, exists, "Expected label %s not found", expectedKey)
+				assert.Equal(t, expectedValue, actualValue, "Label %s value mismatch", expectedKey)
+			}
+
+			// Verify expected annotations are present
+			if len(tc.expectedAnnotations) > 0 {
+				if resultPVC.Annotations == nil {
+					resultPVC.Annotations = make(map[string]string)
+				}
+
+				for expectedKey, expectedValue := range tc.expectedAnnotations {
+					actualValue, exists := resultPVC.Annotations[expectedKey]
+					assert.True(t, exists, "Expected annotation %s not found", expectedKey)
+					assert.Equal(t, expectedValue, actualValue, "Annotation %s value mismatch", expectedKey)
+				}
+			} else if len(tc.expectedAnnotations) == 0 {
+				// If no annotations are expected, verify none were added by the plugin
+				for key := range resultPVC.Annotations {
+					if key == util.OriginalPVCUIDAnnotation {
+						assert.Fail(t, "Unexpected collision annotation found when none expected")
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/plugin/pvc_restore_item_action.go
+++ b/pkg/plugin/pvc_restore_item_action.go
@@ -26,8 +26,12 @@ import (
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 
 	corev1api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
 )
+
 
 // PVCRestoreItemAction is a backup item action for restoring DataVolumes
 type PVCRestoreItemAction struct {
@@ -50,6 +54,7 @@ func (p *PVCRestoreItemAction) AppliesTo() (velero.ResourceSelector, error) {
 // Execute if the PVC and the corresponding DV is not SUCCESSFULL - then skip PVC
 func (p *PVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
 	p.log.Info("Executing PVCRestoreItemAction")
+
 	if input == nil {
 		return nil, fmt.Errorf("input object nil!")
 	}
@@ -58,12 +63,40 @@ func (p *PVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInp
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), &pvc); err != nil {
 		return nil, errors.WithStack(err)
 	}
+
 	p.log.Infof("handling PVC %v/%v", pvc.GetNamespace(), pvc.GetName())
+
 	annotations := pvc.GetAnnotations()
 	_, inProgress := annotations[AnnInProgress]
 	if inProgress {
 		return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
 	}
 
-	return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+	// Remove resource UID labels added during backup
+	if pvc.Labels != nil {
+		if _, exists := pvc.Labels[util.PVCUIDLabel]; exists {
+			// Check if we preserved an original value
+			if pvc.Annotations != nil {
+				if originalValue, hasOriginal := pvc.Annotations[util.OriginalPVCUIDAnnotation]; hasOriginal {
+					// Restore the original value
+					pvc.Labels[util.PVCUIDLabel] = originalValue
+					delete(pvc.Annotations, util.OriginalPVCUIDAnnotation)
+				} else {
+					// No original value to restore - remove the plugin-added label completely
+					delete(pvc.Labels, util.PVCUIDLabel)
+				}
+			} else {
+				// No annotations - remove the plugin-added label
+				delete(pvc.Labels, util.PVCUIDLabel)
+			}
+		}
+	}
+
+	// Convert back to unstructured
+	item, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&pvc)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return velero.NewRestoreItemActionExecuteOutput(&unstructured.Unstructured{Object: item}), nil
 }

--- a/pkg/plugin/pvc_restore_item_action_test.go
+++ b/pkg/plugin/pvc_restore_item_action_test.go
@@ -6,15 +6,22 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	corev1api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
 )
 
 func TestPvcRestoreExecute(t *testing.T) {
 	testCases := []struct {
-		name  string
-		input velero.RestoreItemActionExecuteInput
+		name           string
+		input          velero.RestoreItemActionExecuteInput
+		expectSkip     bool
+		expectedLabels map[string]string
 	}{
-		{"Skip the unfinished PVC ",
+		{
+			"Skip the unfinished PVC",
 			velero.RestoreItemActionExecuteInput{
 				Item: &unstructured.Unstructured{
 					Object: map[string]interface{}{
@@ -37,6 +44,104 @@ func TestPvcRestoreExecute(t *testing.T) {
 					},
 				},
 			},
+			true,
+			nil,
+		},
+		{
+			"Remove resource UID label from PVC",
+			velero.RestoreItemActionExecuteInput{
+				Item: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "PersistentVolumeClaim",
+						"metadata": map[string]interface{}{
+							"name":      "test-pvc",
+							"namespace": "test-namespace",
+							"uid":       "633ab84c-8529-487c-8848-99b40fbda9f5",
+							"labels": map[string]interface{}{
+								util.PVCUIDLabel: "633ab84c-8529-487c-8848-99b40fbda9f5",
+								"other-label":    "other-value",
+							},
+						},
+						"spec": map[string]interface{}{},
+					},
+				},
+			},
+			false,
+			map[string]string{
+				"other-label": "other-value",
+			},
+		},
+		{
+			"Restore original UID label value from collision annotation",
+			velero.RestoreItemActionExecuteInput{
+				Item: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "PersistentVolumeClaim",
+						"metadata": map[string]interface{}{
+							"name":      "collision-pvc",
+							"namespace": "test-namespace",
+							"uid":       "633ab84c-8529-487c-8848-99b40fbda9f5",
+							"labels": map[string]interface{}{
+								util.PVCUIDLabel: "633ab84c-8529-487c-8848-99b40fbda9f5", // Plugin-added during backup
+								"other-label":    "other-value",
+							},
+							"annotations": map[string]interface{}{
+								util.OriginalPVCUIDAnnotation: "original-user-uid-value", // User's original value
+							},
+						},
+						"spec": map[string]interface{}{},
+					},
+				},
+			},
+			false,
+			map[string]string{
+				util.PVCUIDLabel: "original-user-uid-value", // Should be restored to original
+				"other-label":    "other-value",
+			},
+		},
+		{
+			"Handle PVC without resource UID label",
+			velero.RestoreItemActionExecuteInput{
+				Item: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "PersistentVolumeClaim",
+						"metadata": map[string]interface{}{
+							"name":      "test-pvc",
+							"namespace": "test-namespace",
+							"uid":       "789def01-2345-6789-abcd-ef0123456789",
+							"labels": map[string]interface{}{
+								"existing-label": "existing-value",
+							},
+						},
+						"spec": map[string]interface{}{},
+					},
+				},
+			},
+			false,
+			map[string]string{
+				"existing-label": "existing-value",
+			},
+		},
+		{
+			"Handle PVC without any labels",
+			velero.RestoreItemActionExecuteInput{
+				Item: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "PersistentVolumeClaim",
+						"metadata": map[string]interface{}{
+							"name":      "test-pvc",
+							"namespace": "test-namespace",
+						},
+						"spec": map[string]interface{}{},
+					},
+				},
+			},
+			false,
+			map[string]string{},
 		},
 	}
 
@@ -44,8 +149,51 @@ func TestPvcRestoreExecute(t *testing.T) {
 	action := NewPVCRestoreItemAction(logrus.StandardLogger())
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			item, _ := action.Execute(&tc.input)
-			assert.True(t, item.SkipRestore)
+			result, err := action.Execute(&tc.input)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			if tc.expectSkip {
+				assert.True(t, result.SkipRestore)
+				return
+			}
+
+			assert.False(t, result.SkipRestore)
+
+			// Extract the result PVC
+			var resultPVC corev1api.PersistentVolumeClaim
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(result.UpdatedItem.UnstructuredContent(), &resultPVC)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			// Verify expected labels are present and resource name label is removed
+			if tc.expectedLabels == nil {
+				tc.expectedLabels = make(map[string]string)
+			}
+
+			if resultPVC.Labels == nil {
+				resultPVC.Labels = make(map[string]string)
+			}
+
+			assert.Equal(t, len(tc.expectedLabels), len(resultPVC.Labels), "Unexpected number of labels")
+
+			for expectedKey, expectedValue := range tc.expectedLabels {
+				actualValue, exists := resultPVC.Labels[expectedKey]
+				assert.True(t, exists, "Expected label %s not found", expectedKey)
+				assert.Equal(t, expectedValue, actualValue, "Label %s value mismatch", expectedKey)
+			}
+
+			// Verify resource UID label was removed (unless it was restored to original)
+			if tc.expectedLabels[util.PVCUIDLabel] == "" {
+				_, exists := resultPVC.Labels[util.PVCUIDLabel]
+				assert.False(t, exists, "Resource UID label should have been removed")
+			}
+
+			// Verify collision annotation was removed if it existed
+			_, hasCollisionAnnotation := resultPVC.Annotations[util.OriginalPVCUIDAnnotation]
+			assert.False(t, hasCollisionAnnotation, "Collision annotation should have been removed")
 		})
 	}
 }

--- a/pkg/plugin/volumesnapshot_backup_item_action.go
+++ b/pkg/plugin/volumesnapshot_backup_item_action.go
@@ -1,0 +1,175 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2025 Red Hat, Inc.
+ *
+ */
+
+package plugin
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
+
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+)
+
+// VolumeSnapshotBackupItemAction is a backup item action for backing up VolumeSnapshots
+type VolumeSnapshotBackupItemAction struct {
+	log    logrus.FieldLogger
+	client kubernetes.Interface
+	// Cache PVCs by namespace to avoid repeated API calls
+	namespacePVCs map[string]map[string]string // namespace -> pvcName -> pvcUID
+}
+
+// NewVolumeSnapshotBackupItemAction instantiates a VolumeSnapshotBackupItemAction.
+func NewVolumeSnapshotBackupItemAction(log logrus.FieldLogger) *VolumeSnapshotBackupItemAction {
+	client, err := util.GetK8sClient()
+	if err != nil {
+		log.WithError(err).Error("Failed to get Kubernetes client")
+		// Return a basic action that will handle errors during execute
+		return &VolumeSnapshotBackupItemAction{
+			log:           log,
+			namespacePVCs: make(map[string]map[string]string),
+		}
+	}
+
+	return &VolumeSnapshotBackupItemAction{
+		log:           log,
+		client:        client,
+		namespacePVCs: make(map[string]map[string]string),
+	}
+}
+
+// AppliesTo returns information about which resources this action should be invoked for.
+func (p *VolumeSnapshotBackupItemAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+			IncludedResources: []string{
+				"VolumeSnapshot",
+			},
+		},
+		nil
+}
+
+// Execute allows the ItemAction to perform arbitrary logic with the item being backed up,
+// in this case, adding PVC UID labels to VolumeSnapshots for selective restore functionality.
+func (p *VolumeSnapshotBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
+	p.log.Info("Executing VolumeSnapshotBackupItemAction")
+
+	if backup == nil {
+		return nil, nil, fmt.Errorf("backup object nil!")
+	}
+
+	var volumeSnapshot snapshotv1.VolumeSnapshot
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.UnstructuredContent(), &volumeSnapshot); err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	// Check if the VolumeSnapshot has a source PVC
+	if volumeSnapshot.Spec.Source.PersistentVolumeClaimName == nil {
+		extra := []velero.ResourceIdentifier{}
+		return item, extra, nil
+	}
+
+	pvcName := *volumeSnapshot.Spec.Source.PersistentVolumeClaimName
+
+	// Get the PVC UID efficiently using cache
+	pvcUID, err := p.getPVCUID(volumeSnapshot.GetNamespace(), pvcName)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	if pvcUID == "" {
+		extra := []velero.ResourceIdentifier{}
+		return item, extra, nil
+	}
+
+	// Add PVC UID label for selective restore
+	labels := volumeSnapshot.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+
+	// Handle collision detection - preserve original value if it exists
+	// Even if the existing value matches the PVC UID, we need to preserve it
+	// because the user might have legitimately set this label themselves
+	if existingValue, exists := labels[util.PVCUIDLabel]; exists {
+		annotations := volumeSnapshot.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[util.OriginalVolumeSnapshotUIDAnnotation] = existingValue
+		volumeSnapshot.SetAnnotations(annotations)
+	}
+
+	labels[util.PVCUIDLabel] = pvcUID
+	volumeSnapshot.SetLabels(labels)
+
+	vsMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&volumeSnapshot)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	extra := []velero.ResourceIdentifier{}
+	return &unstructured.Unstructured{Object: vsMap}, extra, nil
+}
+
+// getPVCUID efficiently retrieves the UID of a PVC using namespace-level caching
+func (p *VolumeSnapshotBackupItemAction) getPVCUID(namespace, pvcName string) (string, error) {
+	// Check if we have this namespace cached
+	if namespacePVCs, exists := p.namespacePVCs[namespace]; exists {
+		if pvcUID, found := namespacePVCs[pvcName]; found {
+			return pvcUID, nil
+		}
+		// PVC not found in cache but namespace is cached, so it doesn't exist
+		return "", fmt.Errorf("PVC %s not found in namespace %s", pvcName, namespace)
+	}
+
+	// Namespace not cached yet, fetch all PVCs in the namespace at once
+	if p.client == nil {
+		return "", fmt.Errorf("Kubernetes client not available")
+	}
+
+	pvcList, err := p.client.CoreV1().PersistentVolumeClaims(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	// Initialize the namespace cache
+	p.namespacePVCs[namespace] = make(map[string]string)
+
+	// Cache all PVCs in this namespace
+	for _, pvc := range pvcList.Items {
+		p.namespacePVCs[namespace][pvc.Name] = string(pvc.UID)
+	}
+
+	// Now look up the specific PVC
+	if pvcUID, found := p.namespacePVCs[namespace][pvcName]; found {
+		return pvcUID, nil
+	}
+
+	return "", fmt.Errorf("PVC %s not found in namespace %s", pvcName, namespace)
+}

--- a/pkg/plugin/volumesnapshot_backup_item_action_test.go
+++ b/pkg/plugin/volumesnapshot_backup_item_action_test.go
@@ -1,0 +1,235 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
+)
+
+func TestVolumeSnapshotBackupExecute(t *testing.T) {
+	testCases := []struct {
+		name           string
+		volumeSnapshot *snapshotv1.VolumeSnapshot
+		expectedLabels map[string]string
+		expectedAnnotations map[string]string
+		expectSkip     bool
+		mockPVCUID     string
+		mockError      bool
+	}{
+		{
+			"VolumeSnapshot without PVC source should be skipped",
+			&snapshotv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vs",
+					Namespace: "test-namespace",
+					UID:       "vs-uid-123",
+				},
+				Spec: snapshotv1.VolumeSnapshotSpec{
+					Source: snapshotv1.VolumeSnapshotSource{
+						// No PersistentVolumeClaimName set
+					},
+				},
+			},
+			map[string]string{},
+			map[string]string{},
+			true,
+			"",
+			false,
+		},
+		{
+			"Add PVC UID label to VolumeSnapshot with PVC source",
+			&snapshotv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vs",
+					Namespace: "test-namespace",
+					UID:       "vs-uid-123",
+				},
+				Spec: snapshotv1.VolumeSnapshotSpec{
+					Source: snapshotv1.VolumeSnapshotSource{
+						PersistentVolumeClaimName: stringPtr("test-pvc"),
+					},
+				},
+			},
+			map[string]string{
+				util.PVCUIDLabel: "pvc-uid-456",
+			},
+			map[string]string{},
+			false,
+			"pvc-uid-456",
+			false,
+		},
+		{
+			"Preserve existing PVC UID label in annotation when collision occurs",
+			&snapshotv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "collision-vs",
+					Namespace: "test-namespace",
+					UID:       "vs-uid-123",
+					Labels: map[string]string{
+						util.PVCUIDLabel: "original-user-value",
+						"other-label":   "other-value",
+					},
+				},
+				Spec: snapshotv1.VolumeSnapshotSpec{
+					Source: snapshotv1.VolumeSnapshotSource{
+						PersistentVolumeClaimName: stringPtr("test-pvc"),
+					},
+				},
+			},
+			map[string]string{
+				util.PVCUIDLabel: "pvc-uid-456",
+				"other-label":   "other-value",
+			},
+			map[string]string{
+				util.OriginalVolumeSnapshotUIDAnnotation: "original-user-value",
+			},
+			false,
+			"pvc-uid-456",
+			false,
+		},
+		{
+			"Handle VolumeSnapshot with existing labels but no collision",
+			&snapshotv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "existing-labels-vs",
+					Namespace: "test-namespace",
+					UID:       "vs-uid-789",
+					Labels: map[string]string{
+						"existing-label": "existing-value",
+					},
+				},
+				Spec: snapshotv1.VolumeSnapshotSpec{
+					Source: snapshotv1.VolumeSnapshotSource{
+						PersistentVolumeClaimName: stringPtr("test-pvc"),
+					},
+				},
+			},
+			map[string]string{
+				util.PVCUIDLabel:  "pvc-uid-456",
+				"existing-label": "existing-value",
+			},
+			map[string]string{},
+			false,
+			"pvc-uid-456",
+			false,
+		},
+		{
+			"Skip when PVC UID is empty",
+			&snapshotv1.VolumeSnapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-uid-vs",
+					Namespace: "test-namespace",
+					UID:       "vs-uid-789",
+				},
+				Spec: snapshotv1.VolumeSnapshotSpec{
+					Source: snapshotv1.VolumeSnapshotSource{
+						PersistentVolumeClaimName: stringPtr("test-pvc"),
+					},
+				},
+			},
+			map[string]string{},
+			map[string]string{},
+			true,
+			"", // Empty UID should cause skip
+			false,
+		},
+	}
+
+	logger := logrus.StandardLogger()
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create action with mocked client
+			action := &VolumeSnapshotBackupItemAction{
+				log:           logger,
+				client:        nil, // Will be mocked in the action
+				namespacePVCs: make(map[string]map[string]string),
+			}
+
+			// Pre-populate cache if we have a mock PVC UID or need to simulate empty UID
+			if tc.volumeSnapshot.Spec.Source.PersistentVolumeClaimName != nil {
+				action.namespacePVCs[tc.volumeSnapshot.Namespace] = map[string]string{
+					*tc.volumeSnapshot.Spec.Source.PersistentVolumeClaimName: tc.mockPVCUID,
+				}
+			}
+
+			// Convert to unstructured
+			item, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tc.volumeSnapshot)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			backup := &v1.Backup{}
+			result, _, err := action.Execute(&unstructured.Unstructured{Object: item}, backup)
+
+			if tc.expectSkip {
+				// For cases where we skip processing, just verify no error
+				assert.NoError(t, err)
+				assert.NotNil(t, result)
+				return
+			}
+
+			if tc.mockError {
+				assert.Error(t, err)
+				return
+			}
+
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			// Extract the result VolumeSnapshot
+			var resultVS snapshotv1.VolumeSnapshot
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(result.UnstructuredContent(), &resultVS)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			// Verify expected labels are present
+			if resultVS.Labels == nil {
+				resultVS.Labels = make(map[string]string)
+			}
+
+			assert.Equal(t, len(tc.expectedLabels), len(resultVS.Labels), "Unexpected number of labels")
+
+			for expectedKey, expectedValue := range tc.expectedLabels {
+				actualValue, exists := resultVS.Labels[expectedKey]
+				assert.True(t, exists, "Expected label %s not found", expectedKey)
+				assert.Equal(t, expectedValue, actualValue, "Label %s value mismatch", expectedKey)
+			}
+
+			// Verify expected annotations are present
+			if len(tc.expectedAnnotations) > 0 {
+				if resultVS.Annotations == nil {
+					resultVS.Annotations = make(map[string]string)
+				}
+
+				for expectedKey, expectedValue := range tc.expectedAnnotations {
+					actualValue, exists := resultVS.Annotations[expectedKey]
+					assert.True(t, exists, "Expected annotation %s not found", expectedKey)
+					assert.Equal(t, expectedValue, actualValue, "Annotation %s value mismatch", expectedKey)
+				}
+			} else if len(tc.expectedAnnotations) == 0 {
+				// If no annotations are expected, verify none were added by the plugin
+				for key := range resultVS.Annotations {
+					if key == util.OriginalVolumeSnapshotUIDAnnotation {
+						assert.Fail(t, "Unexpected collision annotation found when none expected")
+					}
+				}
+			}
+		})
+	}
+}
+
+// stringPtr returns a pointer to the given string
+func stringPtr(s string) *string {
+	return &s
+}

--- a/pkg/plugin/volumesnapshot_restore_item_action.go
+++ b/pkg/plugin/volumesnapshot_restore_item_action.go
@@ -1,0 +1,98 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2025 Red Hat, Inc.
+ *
+ */
+
+package plugin
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
+)
+
+// VolumeSnapshotRestoreItemAction is a restore item action for restoring VolumeSnapshots
+type VolumeSnapshotRestoreItemAction struct {
+	log logrus.FieldLogger
+}
+
+// NewVolumeSnapshotRestoreItemAction instantiates a VolumeSnapshotRestoreItemAction.
+func NewVolumeSnapshotRestoreItemAction(log logrus.FieldLogger) *VolumeSnapshotRestoreItemAction {
+	return &VolumeSnapshotRestoreItemAction{log: log}
+}
+
+// AppliesTo returns information about which resources this action should be invoked for.
+func (p *VolumeSnapshotRestoreItemAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+			IncludedResources: []string{
+				"VolumeSnapshot",
+			},
+		},
+		nil
+}
+
+// Execute cleans up PVC UID labels added during backup for VolumeSnapshots
+func (p *VolumeSnapshotRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	p.log.Info("Executing VolumeSnapshotRestoreItemAction")
+
+	if input == nil {
+		return nil, fmt.Errorf("input object nil!")
+	}
+
+	var volumeSnapshot snapshotv1.VolumeSnapshot
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), &volumeSnapshot); err != nil {
+		p.log.WithError(err).Error("Failed to convert unstructured item to VolumeSnapshot")
+		return nil, errors.WithStack(err)
+	}
+
+
+	// Remove PVC UID labels added during backup
+	if volumeSnapshot.Labels != nil {
+		if _, exists := volumeSnapshot.Labels[util.PVCUIDLabel]; exists {
+			// Check if we preserved an original value
+			if volumeSnapshot.Annotations != nil {
+				if originalValue, hasOriginal := volumeSnapshot.Annotations[util.OriginalVolumeSnapshotUIDAnnotation]; hasOriginal {
+					// Restore the original value
+					volumeSnapshot.Labels[util.PVCUIDLabel] = originalValue
+					delete(volumeSnapshot.Annotations, util.OriginalVolumeSnapshotUIDAnnotation)
+				} else {
+					// No original value to restore - remove the plugin-added label completely
+					delete(volumeSnapshot.Labels, util.PVCUIDLabel)
+				}
+			} else {
+				// No annotations - remove the plugin-added label
+				delete(volumeSnapshot.Labels, util.PVCUIDLabel)
+			}
+		}
+	}
+
+	// Convert back to unstructured
+	item, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&volumeSnapshot)
+	if err != nil {
+		p.log.WithError(err).Error("Failed to convert VolumeSnapshot back to unstructured")
+		return nil, errors.WithStack(err)
+	}
+	return velero.NewRestoreItemActionExecuteOutput(&unstructured.Unstructured{Object: item}), nil
+}

--- a/pkg/plugin/volumesnapshot_restore_item_action_test.go
+++ b/pkg/plugin/volumesnapshot_restore_item_action_test.go
@@ -1,0 +1,178 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	snapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v7/apis/volumesnapshot/v1"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
+)
+
+func TestVolumeSnapshotRestoreExecute(t *testing.T) {
+	testCases := []struct {
+		name           string
+		input          velero.RestoreItemActionExecuteInput
+		expectedLabels map[string]string
+	}{
+		{
+			"Remove PVC UID label from VolumeSnapshot",
+			velero.RestoreItemActionExecuteInput{
+				Item: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "snapshot.storage.k8s.io/v1",
+						"kind":       "VolumeSnapshot",
+						"metadata": map[string]interface{}{
+							"name":      "test-vs",
+							"namespace": "test-namespace",
+							"uid":       "vs-uid-123",
+							"labels": map[string]interface{}{
+								util.PVCUIDLabel: "pvc-uid-456",
+								"other-label":    "other-value",
+							},
+						},
+						"spec": map[string]interface{}{
+							"source": map[string]interface{}{
+								"persistentVolumeClaimName": "test-pvc",
+							},
+						},
+					},
+				},
+			},
+			map[string]string{
+				"other-label": "other-value",
+			},
+		},
+		{
+			"Restore original PVC UID label value from collision annotation",
+			velero.RestoreItemActionExecuteInput{
+				Item: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "snapshot.storage.k8s.io/v1",
+						"kind":       "VolumeSnapshot",
+						"metadata": map[string]interface{}{
+							"name":      "collision-vs",
+							"namespace": "test-namespace",
+							"uid":       "vs-uid-123",
+							"labels": map[string]interface{}{
+								util.PVCUIDLabel: "pvc-uid-456", // Plugin-added during backup
+								"other-label":    "other-value",
+							},
+							"annotations": map[string]interface{}{
+								util.OriginalVolumeSnapshotUIDAnnotation: "original-user-uid-value", // User's original value
+							},
+						},
+						"spec": map[string]interface{}{
+							"source": map[string]interface{}{
+								"persistentVolumeClaimName": "test-pvc",
+							},
+						},
+					},
+				},
+			},
+			map[string]string{
+				util.PVCUIDLabel: "original-user-uid-value", // Should be restored to original
+				"other-label":    "other-value",
+			},
+		},
+		{
+			"Handle VolumeSnapshot without PVC UID label",
+			velero.RestoreItemActionExecuteInput{
+				Item: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "snapshot.storage.k8s.io/v1",
+						"kind":       "VolumeSnapshot",
+						"metadata": map[string]interface{}{
+							"name":      "test-vs",
+							"namespace": "test-namespace",
+							"uid":       "vs-uid-789",
+							"labels": map[string]interface{}{
+								"existing-label": "existing-value",
+							},
+						},
+						"spec": map[string]interface{}{
+							"source": map[string]interface{}{
+								"persistentVolumeClaimName": "test-pvc",
+							},
+						},
+					},
+				},
+			},
+			map[string]string{
+				"existing-label": "existing-value",
+			},
+		},
+		{
+			"Handle VolumeSnapshot without any labels",
+			velero.RestoreItemActionExecuteInput{
+				Item: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "snapshot.storage.k8s.io/v1",
+						"kind":       "VolumeSnapshot",
+						"metadata": map[string]interface{}{
+							"name":      "test-vs",
+							"namespace": "test-namespace",
+						},
+						"spec": map[string]interface{}{
+							"source": map[string]interface{}{
+								"persistentVolumeClaimName": "test-pvc",
+							},
+						},
+					},
+				},
+			},
+			map[string]string{},
+		},
+	}
+
+	logger := logrus.StandardLogger()
+	action := NewVolumeSnapshotRestoreItemAction(logger)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := action.Execute(&tc.input)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			assert.False(t, result.SkipRestore)
+
+			// Extract the result VolumeSnapshot
+			var resultVS snapshotv1.VolumeSnapshot
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(result.UpdatedItem.UnstructuredContent(), &resultVS)
+			if !assert.NoError(t, err) {
+				return
+			}
+
+			// Verify expected labels are present and PVC UID label is removed (unless restored to original)
+			if tc.expectedLabels == nil {
+				tc.expectedLabels = make(map[string]string)
+			}
+
+			if resultVS.Labels == nil {
+				resultVS.Labels = make(map[string]string)
+			}
+
+			assert.Equal(t, len(tc.expectedLabels), len(resultVS.Labels), "Unexpected number of labels")
+
+			for expectedKey, expectedValue := range tc.expectedLabels {
+				actualValue, exists := resultVS.Labels[expectedKey]
+				assert.True(t, exists, "Expected label %s not found", expectedKey)
+				assert.Equal(t, expectedValue, actualValue, "Label %s value mismatch", expectedKey)
+			}
+
+			// Verify PVC UID label was removed (unless it was restored to original)
+			if tc.expectedLabels[util.PVCUIDLabel] == "" {
+				_, exists := resultVS.Labels[util.PVCUIDLabel]
+				assert.False(t, exists, "PVC UID label should have been removed")
+			}
+
+			// Verify collision annotation was removed if it existed
+			_, hasCollisionAnnotation := resultVS.Annotations[util.OriginalVolumeSnapshotUIDAnnotation]
+			assert.False(t, hasCollisionAnnotation, "Collision annotation should have been removed")
+		})
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -42,6 +42,13 @@ const (
 
 	// VeleroExcludeLabel is used to exclude an object from Velero backups.
 	VeleroExcludeLabel = "velero.io/exclude-from-backup"
+
+	// Resource UID labeling constants for selective restore
+	PVCUIDLabel = "velero.kubevirt.io/pvc-uid"
+
+	// Collision detection annotations to preserve original values
+	OriginalPVCUIDAnnotation = "velero.kubevirt.io/original-pvc-uid"
+	OriginalVolumeSnapshotUIDAnnotation = "velero.kubevirt.io/original-volumesnapshot-uid"
 )
 
 func GetK8sClient() (*kubernetes.Clientset, error) {


### PR DESCRIPTION
Implements PVC and VS labeling during backup/restore with user collision protection

**What this PR does / why we need it**:

  This PR implements selective restore capabilities for PersistentVolumeClaims (PVCs) and VolumeSnapshots (VS) by adding UID-based labeling during backup operations. The plugin now:

  - Labels PVCs and VolumeSnapshots with their UIDs during backup (metadata residing within backup only)
  - Preserves any existing user labels that might conflict with the plugin's labels
  - Restores original user label values after backup/restore operations complete
  - Enables selective restore of specific PVCs and their associated VolumeSnapshots

This functionality is essential for scenarios where multiple VMs and PVCs are backed up together but users need to restore only specific PVCs. It's also a prerequisite for the VM file-level restore feature being developed in https://github.com/migtools/oadp-vm-file-restore/pull/1/files.

How it works:
  1. During backup, the plugin adds UID labels to PVCs and VolumeSnapshots
  2. If users already have labels with the same keys, the plugin preserves the original values
  3. After backup/restore, original user label values are restored exactly as they were
  4. The UID labels enable precise selection during restore operations using Velero's selector(s).

**Special notes for your reviewer**:
  - User label collision protection ensures no data loss of existing labels
  - The labeling mechanism is designed to be transparent to end users
  - This change maintains backward compatibility with existing backup/restore workflows

**Release note**:
```release-note
  Added selective restore support for PersistentVolumeClaims and VolumeSnapshots with UID-based labeling and user label collision protection.
```



# Tests Performed

## 1. New Tests Written

## 2. Manual Tests

### Test Environment Setup
OpenShift with KubeVirt and 4 VMs:

**Virtual Machines:**
```shell
$ oc get vm -n mpryc-vm
NAME                                      AGE     STATUS    READY
mpryc-my-test-vm                          6d18h   Running   True
mpryc-sec-vm-in-same-ns                   6d3h    Running   True
mpryc-third-vm-one-pvcs-plus-shared-pvc   16s     Running   True
mpryc-third-vm-two-pvcs                   5m56s   Running   True
```

**Storage Configuration:**
1. Each VM has its own dedicated PVCs
2. The following 2 VMs have an additional shared PVC:
   - Shared PVC name: `mpryc-third-vm-two-pvcs-disk-ivory-goldfish-17`
   - Used by:
     - `mpryc-third-vm-one-pvcs-plus-shared-pvc`
     - `mpryc-third-vm-two-pvcs`

**PersistentVolumeClaims:**
```shell
$ oc get pvc -n mpryc-vm
NAME                                             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                  AGE
mpryc-my-test-vm                                 Bound    pvc-3a2776ef-2865-4959-bd90-fb96915c6429   3Gi        RWX            ocs-storagecluster-ceph-rbd   6d18h
mpryc-sec-vm-in-same-ns                          Bound    pvc-33cd7007-97f1-4317-b93d-3cca5d425452   30Gi       RWX            ocs-storagecluster-ceph-rbd   6d4h
mpryc-third-vm-one-pvcs-plus-shared-pvc          Bound    pvc-973a4461-d6db-4534-92f6-b709f716cdb1   30Gi       RWX            ocs-storagecluster-ceph-rbd   45m
mpryc-third-vm-two-pvcs                          Bound    pvc-4e4b0630-7ec1-4893-976a-f6df4f437e04   30Gi       RWX            ocs-storagecluster-ceph-rbd   49m
mpryc-third-vm-two-pvcs-disk-ivory-goldfish-17   Bound    pvc-7041f1cb-4e0e-4bd1-be4a-c8d48e3949e7   5Gi        RWX            ocs-storagecluster-ceph-rbd   49m
```

## Test Procedures

### 1. Creating Backup

```shell
$ cat ./vm-backup.yaml
kind: Backup
apiVersion: velero.io/v1
metadata:
  name: mpryc-vm-backup-modified-kubevirt-plugin
  namespace: openshift-adp
spec:
  csiSnapshotTimeout: 10m0s
  defaultVolumesToFsBackup: false
  includedNamespaces:
    - mpryc-vm
  itemOperationTimeout: 4h0m0s
  snapshotMoveData: false
  storageLocation: ts-dpa-1
  ttl: 720h0m0s


$ oc apply -f ./vm-backup.yaml
backup.velero.io/mpryc-vm-backup-modified-kubevirt-plugin

$ velero backup get mpryc-vm-backup-modified-kubevirt-plugin
NAME                                       STATUS      ERRORS   WARNINGS   CREATED                          EXPIRES   STORAGE LOCATION   SELECTOR
mpryc-vm-backup-modified-kubevirt-plugin   Completed   0        0          2025-09-24 14:56:16 +0200 CEST   29d       ts-dpa-1           <none>
```

### 2. Backup Details

```shell
$ velero backup describe mpryc-vm-backup-modified-kubevirt-plugin

# [...] output truncated

Resource List:
  snapshot.storage.k8s.io/v1/VolumeSnapshotContent:
    - snapcontent-2255e01c-da18-4d50-b0aa-60f03cbfd0c1
    - snapcontent-3450dfd1-e4f8-4ff2-8d7a-8374f0a4788a
    - snapcontent-8c127646-c6ba-4f1f-be30-5d8fa106437d
    - snapcontent-c351e614-04bc-41de-933d-e848e385f029
    - snapcontent-ea2a4110-86fa-4b68-8b56-57967b58a90d
    - snapcontent-fa4ee301-0219-4947-9b36-cb742a5411cb
  v1/PersistentVolume:
    - pvc-33cd7007-97f1-4317-b93d-3cca5d425452
    - pvc-3a2776ef-2865-4959-bd90-fb96915c6429
    - pvc-4e4b0630-7ec1-4893-976a-f6df4f437e04
    - pvc-7041f1cb-4e0e-4bd1-be4a-c8d48e3949e7
    - pvc-973a4461-d6db-4534-92f6-b709f716cdb1
  v1/PersistentVolumeClaim:
    - mpryc-vm/mpryc-my-test-vm
    - mpryc-vm/mpryc-sec-vm-in-same-ns
    - mpryc-vm/mpryc-third-vm-one-pvcs-plus-shared-pvc
    - mpryc-vm/mpryc-third-vm-two-pvcs
    - mpryc-vm/mpryc-third-vm-two-pvcs-disk-ivory-goldfish-17

Backup Volumes:
  CSI Snapshots:
    mpryc-vm/mpryc-my-test-vm:
      Snapshot:
        Operation ID: mpryc-vm/velero-mpryc-my-test-vm-pmtm9/2025-09-24T12:56:23Z
        Snapshot Content Name: snapcontent-3450dfd1-e4f8-4ff2-8d7a-8374f0a4788a
        Storage Snapshot ID: 0001-0011-openshift-storage-0000000000000002-5a700a05-5837-46ba-ac04-2e51df56fb3e
        Snapshot Size (bytes): 3221225472
        CSI Driver: openshift-storage.rbd.csi.ceph.com
        Result: 
    mpryc-vm/mpryc-sec-vm-in-same-ns:
      Snapshot:
        Operation ID: mpryc-vm/velero-mpryc-sec-vm-in-same-ns-r75kj/2025-09-24T12:56:28Z
        Snapshot Content Name: snapcontent-fa4ee301-0219-4947-9b36-cb742a5411cb
        Storage Snapshot ID: 0001-0011-openshift-storage-0000000000000002-e8766c1c-c25a-431a-80dd-79fc6e284729
        Snapshot Size (bytes): 32212254720
        CSI Driver: openshift-storage.rbd.csi.ceph.com
        Result: 
    mpryc-vm/mpryc-third-vm-one-pvcs-plus-shared-pvc:
      Snapshot:
        Operation ID: mpryc-vm/velero-mpryc-third-vm-one-pvcs-plus-shared-pvc-ghjdw/2025-09-24T12:56:33Z
        Snapshot Content Name: snapcontent-2255e01c-da18-4d50-b0aa-60f03cbfd0c1
        Storage Snapshot ID: 0001-0011-openshift-storage-0000000000000002-32e9e473-2311-4ea3-99ec-ae782cc2c06a
        Snapshot Size (bytes): 32212254720
        CSI Driver: openshift-storage.rbd.csi.ceph.com
        Result: 
    mpryc-vm/mpryc-third-vm-two-pvcs-disk-ivory-goldfish-17:
      Snapshot:
        Operation ID: mpryc-vm/velero-mpryc-third-vm-two-pvcs-disk-ivory-goldfish-17-fj6sl/2025-09-24T12:56:39Z
        Snapshot Content Name: snapcontent-8c127646-c6ba-4f1f-be30-5d8fa106437d
        Storage Snapshot ID: 0001-0011-openshift-storage-0000000000000002-e29a7130-0b1b-4c7a-80bc-50a6f936d404
        Snapshot Size (bytes): 5368709120
        CSI Driver: openshift-storage.rbd.csi.ceph.com
        Result: 
    mpryc-vm/mpryc-third-vm-two-pvcs:
      Snapshot:
        Operation ID: mpryc-vm/velero-mpryc-third-vm-two-pvcs-j62mk/2025-09-24T12:56:44Z
        Snapshot Content Name: snapcontent-c351e614-04bc-41de-933d-e848e385f029
        Storage Snapshot ID: 0001-0011-openshift-storage-0000000000000002-8010658a-8e87-4964-b279-1c5264af42f0
        Snapshot Size (bytes): 32212254720
        CSI Driver: openshift-storage.rbd.csi.ceph.com
        Result: 
```

### 3. Downloading Metadata and Confirming New Annotations
```shell

$ velero backup download mpryc-vm-backup-modified-kubevirt-plugin
Backup mpryc-vm-backup-modified-kubevirt-plugin has been successfully downloaded to /home/migi/Development/Upstream/OADP/mpryc-kubevirt-velero-plugin/mpryc-vm-backup-modified-kubevirt-plugin-data.tar.gz

$ tar -xvf mpryc-vm-backup-modified-kubevirt-plugin-data.tar.gz

# Confirm the labels are applied:
$ grep -r --include='*.json' -H -o '"velero\.kubevirt\.io/\(pvc-uid\|original-pvc-uid\|original-volumesnapshot-uid\)"[[:space:]]*:[[:space:]]*"[^"]*"' resources/   | grep -v 'v1-preferredversion'   | sed -E 's|(.*):"([^"]+)": *"([^"]+)"|\1 \n  LABEL:     \2=\3|'
resources/volumesnapshots.snapshot.storage.k8s.io/namespaces/mpryc-vm/velero-mpryc-my-test-vm-pmtm9.json 
  LABEL:     velero.kubevirt.io/pvc-uid=c7514c0f-86a3-49d8-a8f8-18babd9c80f5
resources/volumesnapshots.snapshot.storage.k8s.io/namespaces/mpryc-vm/velero-mpryc-sec-vm-in-same-ns-r75kj.json 
  LABEL:     velero.kubevirt.io/pvc-uid=c7f96f1f-0051-44d7-aa12-84085e53376b
resources/volumesnapshots.snapshot.storage.k8s.io/namespaces/mpryc-vm/velero-mpryc-third-vm-one-pvcs-plus-shared-pvc-ghjdw.json 
  LABEL:     velero.kubevirt.io/pvc-uid=8c52a10e-dd6b-430b-b6a3-55d1082f0d20
resources/volumesnapshots.snapshot.storage.k8s.io/namespaces/mpryc-vm/velero-mpryc-third-vm-two-pvcs-disk-ivory-goldfish-17-fj6sl.json 
  LABEL:     velero.kubevirt.io/pvc-uid=3daa61e0-e723-4667-a5ab-fdc8e72aa4e7
resources/volumesnapshots.snapshot.storage.k8s.io/namespaces/mpryc-vm/velero-mpryc-third-vm-two-pvcs-j62mk.json 
  LABEL:     velero.kubevirt.io/pvc-uid=eda88c6d-6752-4b0a-99a2-fd4da234a451
resources/volumesnapshots.snapshot.storage.k8s.io/namespaces/mpryc-vm/my-vs.json 
  LABEL:     velero.kubevirt.io/pvc-uid=c7514c0f-86a3-49d8-a8f8-18babd9c80f5
resources/persistentvolumeclaims/namespaces/mpryc-vm/mpryc-my-test-vm.json 
  LABEL:     velero.kubevirt.io/pvc-uid=c7514c0f-86a3-49d8-a8f8-18babd9c80f5
resources/persistentvolumeclaims/namespaces/mpryc-vm/mpryc-sec-vm-in-same-ns.json 
  LABEL:     velero.kubevirt.io/pvc-uid=c7f96f1f-0051-44d7-aa12-84085e53376b
resources/persistentvolumeclaims/namespaces/mpryc-vm/mpryc-third-vm-one-pvcs-plus-shared-pvc.json 
  LABEL:     velero.kubevirt.io/pvc-uid=8c52a10e-dd6b-430b-b6a3-55d1082f0d20
resources/persistentvolumeclaims/namespaces/mpryc-vm/mpryc-third-vm-two-pvcs-disk-ivory-goldfish-17.json 
  LABEL:     velero.kubevirt.io/pvc-uid=3daa61e0-e723-4667-a5ab-fdc8e72aa4e7
resources/persistentvolumeclaims/namespaces/mpryc-vm/mpryc-third-vm-two-pvcs.json 
  LABEL:     velero.kubevirt.io/pvc-uid=eda88c6d-6752-4b0a-99a2-fd4da234a451
```

### 4. Create Test Namespaces for Restore Operations

```shell
$ oc create ns mpryc-vm-restore-modified-kubevirt-plugin-data-v1
namespace/mpryc-vm-restore-modified-kubevirt-plugin-data-v1 created
$ oc create ns mpryc-vm-restore-modified-kubevirt-plugin-data-v2
namespace/mpryc-vm-restore-modified-kubevirt-plugin-data-v2 created
$ oc create ns mpryc-vm-restore-modified-kubevirt-plugin-data-v3
namespace/mpryc-vm-restore-modified-kubevirt-plugin-data-v3 created
```

### 5. Restore Operation Tests

#### 5a. Restore Single PVC (Non-Shared PV) to v1 Namespace

```shell
$ velero restore create   \
    --from-backup mpryc-vm-backup-modified-kubevirt-plugin \
    --include-resources persistentvolumeclaims,volumesnapshots  \
    --namespace-mappings mpryc-vm:mpryc-vm-restore-modified-kubevirt-plugin-data-v1 \
    --selector velero.kubevirt.io/pvc-uid=c7514c0f-86a3-49d8-a8f8-18babd9c80f5
Restore request "mpryc-vm-backup-modified-kubevirt-plugin-20250924151420" submitted successfully.
Run `velero restore describe mpryc-vm-backup-modified-kubevirt-plugin-20250924151420` or `velero restore logs mpryc-vm-backup-modified-kubevirt-plugin-20250924151420` for more details.

$ velero restore describe mpryc-vm-backup-modified-kubevirt-plugin-20250924151420    

# [...] output truncated

CSI Snapshot Restores:
  mpryc-vm-restore-modified-kubevirt-plugin-data-v1/mpryc-my-test-vm:
    Snapshot:
      Snapshot Content Name: velero-mpryc-my-test-vm-pmtm9-hzs8m
      Storage Snapshot ID: 0001-0011-openshift-storage-0000000000000002-5a700a05-5837-46ba-ac04-2e51df56fb3e
      CSI Driver: openshift-storage.rbd.csi.ceph.com

$ oc get pvc -n  mpryc-vm-restore-modified-kubevirt-plugin-data-v1
NAME               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                  AGE
mpryc-my-test-vm   Bound    pvc-b6672719-5110-4bbd-8639-1d47dbdb13b3   3Gi        RWX            ocs-storagecluster-ceph-rbd   81s

$ oc describe  pvc -n  mpryc-vm-restore-modified-kubevirt-plugin-data-v1 mpryc-my-test-vm

# [...] output truncated - labels on the pvc prior to backup exists, no new uid labels added

Labels:        app=containerized-data-importer
               app.kubernetes.io/component=storage
               app.kubernetes.io/managed-by=cdi-controller
               app.kubernetes.io/part-of=hyperconverged-cluster
               app.kubernetes.io/version=4.15.12
               kubevirt.io/created-by=ef0dc743-af73-4ab5-acc4-011a4bd6ef6d
               ownlabel/preserveme=123456
               velero.io/backup-name=mpryc-vm-backup-modified-kubevirt-plugin
               velero.io/restore-name=mpryc-vm-backup-modified-kubevirt-plugin-20250924151420
               velero.io/volume-snapshot-name=velero-mpryc-my-test-vm-pmtm9

DataSource:
  APIGroup:  snapshot.storage.k8s.io
  Kind:      VolumeSnapshot
  Name:      velero-mpryc-my-test-vm-pmtm9

$ oc describe vs velero-mpryc-my-test-vm-pmtm9 -n mpryc-vm-restore-modified-kubevirt-plugin-data-v1

# [...] output truncated - labels on the pvc prior to backup exists, no new uid labels added

Name:         velero-mpryc-my-test-vm-pmtm9
Namespace:    mpryc-vm-restore-modified-kubevirt-plugin-data-v1
Labels:       app=containerized-data-importer
              app.kubernetes.io/component=storage
              app.kubernetes.io/managed-by=cdi-controller
              app.kubernetes.io/part-of=hyperconverged-cluster
              app.kubernetes.io/version=4.15.12
              kubevirt.io/created-by=ef0dc743-af73-4ab5-acc4-011a4bd6ef6d
              ownlabel/preserveme=123456
              velero.io/backup-name=mpryc-vm-backup-modified-kubevirt-plugin
              velero.io/restore-name=mpryc-vm-backup-modified-kubevirt-plugin-20250924151420
Annotations:  velero.io/csi-driver-name: openshift-storage.rbd.csi.ceph.com
              velero.io/csi-volumesnapshot-handle: 0001-0011-openshift-storage-0000000000000002-5a700a05-5837-46ba-ac04-2e51df56fb3e
              velero.io/csi-volumesnapshot-restore-size: 3Gi
              velero.io/csi-vsc-deletion-policy: Retain


# Confirm the backup snapshot handle is same as volume snapshot for restore:

$ cat resources/volumesnapshots.snapshot.storage.k8s.io/v1-preferredversion/namespaces/mpryc-vm/velero-mpryc-my-test-vm-pmtm9.json|jq

# [...] output truncated - labels on the pvc prior to backup exists, no new uid labels added

  "status": {
    "boundVolumeSnapshotContentName": "snapcontent-3450dfd1-e4f8-4ff2-8d7a-8374f0a4788a",
    "creationTime": "2025-09-24T12:56:18Z",
    "readyToUse": true,
    "restoreSize": "3Gi"
  }


$ oc describe vsc snapcontent-3450dfd1-e4f8-4ff2-8d7a-8374f0a4788a
Name:         snapcontent-3450dfd1-e4f8-4ff2-8d7a-8374f0a4788a
Namespace:    
Labels:       velero.io/backup-name=mpryc-vm-backup-modified-kubevirt-plugin
Annotations:  snapshot.storage.kubernetes.io/deletion-secret-name: rook-csi-rbd-provisioner
              snapshot.storage.kubernetes.io/deletion-secret-namespace: openshift-storage
              snapshot.storage.kubernetes.io/volumesnapshot-being-deleted: yes
API Version:  snapshot.storage.k8s.io/v1
Kind:         VolumeSnapshotContent
Metadata:
  Creation Timestamp:  2025-09-24T12:56:18Z
  Finalizers:
    snapshot.storage.kubernetes.io/volumesnapshotcontent-bound-protection
  Generation:        1
  Resource Version:  17574703
  UID:               0d040d63-442a-4c6c-b133-4f4e2d880dbd
Spec:
  Deletion Policy:  Retain
  Driver:           openshift-storage.rbd.csi.ceph.com
  Source:
    Volume Handle:             0001-0011-openshift-storage-0000000000000002-15c9d73d-f63a-4601-a7ff-9ee141189703
  Volume Snapshot Class Name:  example-snapclass
  Volume Snapshot Ref:
    API Version:       snapshot.storage.k8s.io/v1
    Kind:              VolumeSnapshot
    Name:              velero-mpryc-my-test-vm-pmtm9
    Namespace:         mpryc-vm
    Resource Version:  17574243
    UID:               3450dfd1-e4f8-4ff2-8d7a-8374f0a4788a
Status:
  Creation Time:    1758718578822583118
  Ready To Use:     true
  Restore Size:     3221225472
  Snapshot Handle:  0001-0011-openshift-storage-0000000000000002-5a700a05-5837-46ba-ac04-2e51df56fb3e
Events:             <none>


$ oc describe vsc velero-mpryc-my-test-vm-pmtm9-hzs8m
Name:         velero-mpryc-my-test-vm-pmtm9-hzs8m
Namespace:    
Labels:       velero.io/restore-name=mpryc-vm-backup-modified-kubevirt-plugin-20250924151420
Annotations:  <none>
API Version:  snapshot.storage.k8s.io/v1
Kind:         VolumeSnapshotContent
Metadata:
  Creation Timestamp:  2025-09-24T13:14:22Z
  Finalizers:
    snapshot.storage.kubernetes.io/volumesnapshotcontent-bound-protection
  Generate Name:     velero-mpryc-my-test-vm-pmtm9-
  Generation:        2
  Resource Version:  17589713
  UID:               89b0e5d4-0055-40ce-8f8d-5b35f029036e
Spec:
  Deletion Policy:  Retain
  Driver:           openshift-storage.rbd.csi.ceph.com
  Source:
    Snapshot Handle:           0001-0011-openshift-storage-0000000000000002-5a700a05-5837-46ba-ac04-2e51df56fb3e
  Volume Snapshot Class Name:  example-snapclass
  Volume Snapshot Ref:
    API Version:  snapshot.storage.k8s.io/v1
    Kind:         VolumeSnapshot
    Name:         velero-mpryc-my-test-vm-pmtm9
    Namespace:    mpryc-vm-restore-modified-kubevirt-plugin-data-v1
    UID:          33f6b62f-7634-48c7-b0a9-f56857b712c6
Status:
  Creation Time:    1758719662091485929
  Ready To Use:     true
  Restore Size:     0
  Snapshot Handle:  0001-0011-openshift-storage-0000000000000002-5a700a05-5837-46ba-ac04-2e51df56fb3e
Events:             <none>
```

#### Restore Process Summary
```shell
# Backup: VolumeSnapshotContent created
VSC: snapcontent-3450dfd1-e4f8-4ff2-8d7a-8374f0a4788a
SnapshotHandle: 0001-0011-openshift-storage-...-5a700a05-5837-46ba-ac04-2e51df56fb3e

   |
   v

# Restore: new VolumeSnapshotContent created
VSC: velero-mpryc-my-test-vm-pmtm9-hzs8m
SnapshotHandle: 0001-0011-openshift-storage-...-5a700a05-5837-46ba-ac04-2e51df56fb3e   <-- SAME

   |
   v

# Restored VolumeSnapshot
Name: velero-mpryc-my-test-vm-pmtm9
Bound to VSC above

   |
   v

# Restored PVC in test NS
Name: mpryc-my-test-vm
DataSource: VolumeSnapshot/velero-mpryc-my-test-vm-pmtm9
→ provisioned from SAME backend snapshot data
```

#### 5b. Restore Multiple PVCs Using OR Selector to v2 Namespace

```shell
$ velero restore create   \
    --from-backup mpryc-vm-backup-modified-kubevirt-plugin \
    --include-resources persistentvolumeclaims,volumesnapshots  \
    --namespace-mappings mpryc-vm:mpryc-vm-restore-modified-kubevirt-plugin-data-v2 \
    --or-selector "velero.kubevirt.io/pvc-uid=8c52a10e-dd6b-430b-b6a3-55d1082f0d20 or velero.kubevirt.io/pvc-uid=c7514c0f-86a3-49d8-a8f8-18babd9c80f5"
    
Restore request "mpryc-vm-backup-modified-kubevirt-plugin-20250924153204" submitted successfully.
Run `velero restore describe mpryc-vm-backup-modified-kubevirt-plugin-20250924153204` or `velero restore logs mpryc-vm-backup-modified-kubevirt-plugin-20250924153204` for more details.

$ oc get pvc -n  mpryc-vm-restore-modified-kubevirt-plugin-data-v2
NAME                                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                  AGE
mpryc-my-test-vm                          Bound    pvc-5fecd96d-98c7-4e0f-82db-57801288af7f   3Gi        RWX            ocs-storagecluster-ceph-rbd   17s
mpryc-third-vm-one-pvcs-plus-shared-pvc   Bound    pvc-56eac0eb-9892-4716-a67b-01ad66a96ffa   30Gi       RWX            ocs-storagecluster-ceph-rbd   17s
```

#### 5c. Restore All PVCs to v3 Namespace

```shell
$ velero restore create   \
    --from-backup mpryc-vm-backup-modified-kubevirt-plugin \
    --include-resources persistentvolumeclaims,volumesnapshots  \
    --namespace-mappings mpryc-vm:mpryc-vm-restore-modified-kubevirt-plugin-data-v3

Restore request "mpryc-vm-backup-modified-kubevirt-plugin-20250924153255" submitted successfully.
Run `velero restore describe mpryc-vm-backup-modified-kubevirt-plugin-20250924153255` or `velero restore logs mpryc-vm-backup-modified-kubevirt-plugin-20250924153255` for more details.

$ oc get pvc -n  mpryc-vm-restore-modified-kubevirt-plugin-data-v3
NAME                                             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                  AGE
mpryc-my-test-vm                                 Bound    pvc-27e01495-9847-42f8-a88e-dee32bc6f43d   3Gi        RWX            ocs-storagecluster-ceph-rbd   42s
mpryc-sec-vm-in-same-ns                          Bound    pvc-e677bbe2-586b-4647-9e7d-08c5373817f8   30Gi       RWX            ocs-storagecluster-ceph-rbd   42s
mpryc-third-vm-one-pvcs-plus-shared-pvc          Bound    pvc-41d18530-6424-4e5e-8906-478cb680039a   30Gi       RWX            ocs-storagecluster-ceph-rbd   42s
mpryc-third-vm-two-pvcs                          Bound    pvc-4eda5e0c-c994-49db-9bcc-f09f691a52ef   30Gi       RWX            ocs-storagecluster-ceph-rbd   42s
mpryc-third-vm-two-pvcs-disk-ivory-goldfish-17   Bound    pvc-038ee2d1-ddca-4730-b05e-36c87d30b45c   5Gi        RWX            ocs-storagecluster-ceph-rbd   42s
```




### 6. Testing User Label Collision Protection

#### Expected Behavior:
- **PVC UID:** `c7514c0f-86a3-49d8-a8f8-18babd9c80f5`
  - **LABEL:** `velero.kubevirt.io/pvc-uid=c7514c0f-86a3-49d8-a8f8-18babd9c80f5` (should be preserved)
- **PVC UID:** `c7f96f1f-0051-44d7-aa12-84085e53376b`
  - **LABEL:** `velero.kubevirt.io/pvc-uid=differentuservalue` (user's existing value should be preserved)

```shell
$ oc create ns mpryc-vm-restore-modified-kubevirt-plugin-data-v4
namespace/mpryc-vm-restore-modified-kubevirt-plugin-data-v4 created

$ oc apply -f ./vm-backup.yaml 
backup.velero.io/mpryc-vm-backup-modified-kubevirt-plugin-v4 created

$ velero get backup mpryc-vm-backup-modified-kubevirt-plugin-v4
NAME                                        STATUS      ERRORS   WARNINGS   CREATED                          EXPIRES   STORAGE LOCATION   SELECTOR
mpryc-vm-backup-modified-kubevirt-plugin-v4   Completed   0        0          2025-09-24 15:39:55 +0200 CEST   29d       ts-dpa-1           <none>

$ velero restore create   \
    --from-backup mpryc-vm-backup-modified-kubevirt-plugin-v4 \
    --include-resources persistentvolumeclaims,volumesnapshots  \
    --namespace-mappings mpryc-vm:mpryc-vm-restore-modified-kubevirt-plugin-data-v4 \
    --or-selector "velero.kubevirt.io/pvc-uid=c7514c0f-86a3-49d8-a8f8-18babd9c80f5 or velero.kubevirt.io/pvc-uid=c7f96f1f-0051-44d7-aa12-84085e53376b"

Restore request "mpryc-vm-backup-modified-kubevirt-plugin-v4-20250924154152" submitted successfully.
Run `velero restore describe mpryc-vm-backup-modified-kubevirt-plugin-v4-20250924154152` or `velero restore logs mpryc-vm-backup-modified-kubevirt-plugin-v4-20250924154152` for more details.

$ oc get pvc -n  mpryc-vm-restore-modified-kubevirt-plugin-data-v4
NAME                      STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS                  AGE
mpryc-my-test-vm          Bound    pvc-5af4e888-70c2-41a2-965f-bc18d04482a7   3Gi        RWX            ocs-storagecluster-ceph-rbd   36s
mpryc-sec-vm-in-same-ns   Bound    pvc-2f0fcd2b-244e-4518-a012-eb63ae308170   30Gi       RWX            ocs-storagecluster-ceph-rbd   36s

#### 6a. Verify Label Preservation After Restore

**First PVC (mpryc-my-test-vm):**
```shell
$ oc describe pvc -n mpryc-vm-restore-modified-kubevirt-plugin-data-v4 mpryc-my-test-vm
Labels:        app=containerized-data-importer
               app.kubernetes.io/component=storage
               app.kubernetes.io/managed-by=cdi-controller
               app.kubernetes.io/part-of=hyperconverged-cluster
               app.kubernetes.io/version=4.15.12
               kubevirt.io/created-by=ef0dc743-af73-4ab5-acc4-011a4bd6ef6d
               velero.io/backup-name=mpryc-vm-backup-modified-kubevirt-plugin-v4
               velero.io/restore-name=mpryc-vm-backup-modified-kubevirt-plugin-v4-20250924160351
               velero.io/volume-snapshot-name=velero-mpryc-my-test-vm-4k8ps
               velero.kubevirt.io/pvc-uid=c7514c0f-86a3-49d8-a8f8-18babd9c80f5
```

**Second PVC (mpryc-sec-vm-in-same-ns):**
```shell
$ oc describe pvc -n mpryc-vm-restore-modified-kubevirt-plugin-data-v4 mpryc-sec-vm-in-same-ns
Labels:        app=containerized-data-importer
               app.kubernetes.io/component=storage
               app.kubernetes.io/managed-by=cdi-controller
               app.kubernetes.io/part-of=hyperconverged-cluster
               app.kubernetes.io/version=4.15.12
               kubevirt.io/created-by=2624f6e0-2257-4b35-9894-7f6382b44e13
               velero.io/backup-name=mpryc-vm-backup-modified-kubevirt-plugin-v4
               velero.io/restore-name=mpryc-vm-backup-modified-kubevirt-plugin-v4-20250924160351
               velero.io/volume-snapshot-name=velero-mpryc-sec-vm-in-same-ns-l2tz2
               velero.kubevirt.io/pvc-uid=differentuservalue
```

## Test Results Summary

The testing demonstrates that:

1. **Backup Operation**: Successfully labels PVCs and VolumeSnapshots with UID-based labels during backup
2. **Selective Restore**: Enables precise restoration of specific PVCs using UID selectors
3. **User Label Protection**: Preserves existing user labels that conflict with plugin labels
4. **Data Integrity**: Restored PVCs use the same underlying storage snapshots as the original backup

