### PR TITLE
UPSTREAM: <carry>: Update konflux.Dockerfile golang builder to 1.25

### DIFF
--- a/konflux.Dockerfile
+++ b/konflux.Dockerfile
@@ -1,4 +1,4 @@
-FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.24 AS builder
+FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_golang_1.25 AS builder
 
 COPY . /workspace
 WORKDIR /workspace/


### PR DESCRIPTION
## Summary
- Update the golang builder image from `rhel_9_golang_1.24` to `rhel_9_golang_1.25` in `konflux.Dockerfile`
- The `go.mod` requires `go 1.25.7` but the builder was still on 1.24, causing a mismatch

## Test plan
- [ ] Verify Konflux build succeeds with the updated builder image

🤖 Generated with [Claude Code](https://claude.com/claude-code)